### PR TITLE
Refine error handling

### DIFF
--- a/src/adapters/manga-here.js
+++ b/src/adapters/manga-here.js
@@ -116,7 +116,11 @@ const MangaHereAdapter: SiteAdapter = {
   },
 
   constructUrl(seriesSlug, chapterSlug) {
-    invariant(seriesSlug, new TypeError('Series slug must be non-null'));
+    invariant(
+      typeof seriesSlug === 'string',
+      new TypeError(`'seriesSlug' must be a string, not ${typeof seriesSlug}`),
+    );
+
     return utils.normalizeUrl(
       `${this._getHost()}/manga/${seriesSlug}/${chapterSlug || ''}`,
     );

--- a/src/adapters/manga-rock.js
+++ b/src/adapters/manga-rock.js
@@ -62,7 +62,11 @@ const MangaRockAdapter: SiteAdapter = {
   },
 
   constructUrl(seriesSlug, chapterSlug) {
-    invariant(seriesSlug, new TypeError('Series slug must be non-null'));
+    invariant(
+      typeof seriesSlug === 'string',
+      new TypeError(`'seriesSlug' must be a string, not ${typeof seriesSlug}`),
+    );
+
     const parts = [
       'https://mangarock.com/manga',
       `mrs-serie-${seriesSlug}`,

--- a/src/adapters/manga-updates.js
+++ b/src/adapters/manga-updates.js
@@ -72,7 +72,7 @@ const MangaUpdatesAdapter: SiteAdapter = {
   },
 
   async getChapter() {
-    throw new errors.UnsupportedSiteRequestError(
+    throw new errors.UnsupportedOperationError(
       this.name,
       'fetching chapters',
     );

--- a/src/adapters/manga-updates.js
+++ b/src/adapters/manga-updates.js
@@ -33,7 +33,11 @@ const MangaUpdatesAdapter: SiteAdapter = {
   },
 
   constructUrl(seriesSlug) {
-    invariant(seriesSlug, new TypeError('Series slug must be non-null'));
+    invariant(
+      typeof seriesSlug === 'string',
+      new TypeError(`'seriesSlug' must be a string, not ${typeof seriesSlug}`),
+    );
+
     return utils.normalizeUrl(
       `${this._getHost()}/series.html?id=${seriesSlug}`,
     );

--- a/src/adapters/mangadex.js
+++ b/src/adapters/mangadex.js
@@ -53,7 +53,9 @@ const MangadexAdapter: SiteAdapter = {
 
     invariant(
       slug,
-      new TypeError('Either series or chapter slug must be non-null'),
+      new TypeError(
+        `Either 'seriesSlug' or 'chapterSlug' must be a string, not ${typeof seriesSlug} and ${typeof chapterSlug}`,
+      ),
     );
 
     return utils.normalizeUrl(`${this._getHost()}/${type}/${slug}`);

--- a/src/errors.js
+++ b/src/errors.js
@@ -4,7 +4,8 @@ type ErrorCode =
   | 'INVALID_URL'
   | 'UNSUPPORTED_SITE'
   | 'UNSUPPORTED_SITE_REQUEST'
-  | 'NOT_FOUND';
+  | 'TIMEOUT'
+  | 'HTTP_ERROR';
 
 class PoketoError extends Error {
   code: ErrorCode;
@@ -18,13 +19,30 @@ class PoketoError extends Error {
 
 class InvalidUrlError extends PoketoError {
   constructor(url: string) {
-    super('INVALID_URL', `Could not parse url '${url}'`);
+    super('INVALID_URL', `Unable to parse url '${url}'`);
   }
 }
 
-class NotFoundError extends PoketoError {
+class HTTPError extends PoketoError {
+  statusCode: number;
+  url: string;
+
+  constructor(statusCode: number, message: string, url: string) {
+    super('HTTP_ERROR', message);
+    this.statusCode = statusCode;
+    this.url = url;
+  }
+}
+
+class NotFoundError extends HTTPError {
   constructor(url: string) {
-    super('NOT_FOUND', `Could not find resource at '${url}'`);
+    super(404, 'Not Found', url);
+  }
+}
+
+class TimeoutError extends PoketoError {
+  constructor(message: string, url: string) {
+    super('TIMEOUT', message);
   }
 }
 
@@ -45,8 +63,10 @@ class UnsupportedSiteRequestError extends PoketoError {
 
 export default {
   PoketoError,
+  HTTPError,
   InvalidUrlError,
   NotFoundError,
+  TimeoutError,
   UnsupportedSiteError,
   UnsupportedSiteRequestError,
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,8 +1,9 @@
 // @flow
 
 type ErrorCode =
-  | 'INVALID_URL'
+  | 'ERROR'
   | 'HTTP_ERROR'
+  | 'INVALID_URL'
   | 'REQUEST_ERROR'
   | 'UNSUPPORTED_SITE'
   | 'UNSUPPORTED_OPERATION'

--- a/src/errors.js
+++ b/src/errors.js
@@ -2,13 +2,15 @@
 
 type ErrorCode =
   | 'INVALID_URL'
+  | 'HTTP_ERROR'
+  | 'REQUEST_ERROR'
   | 'UNSUPPORTED_SITE'
-  | 'UNSUPPORTED_SITE_REQUEST'
-  | 'TIMEOUT'
-  | 'HTTP_ERROR';
+  | 'UNSUPPORTED_OPERATION'
+  | 'TIMEOUT';
 
 class PoketoError extends Error {
   code: ErrorCode;
+
   constructor(errorCode: ErrorCode, message: string) {
     super(message);
     Error.captureStackTrace(this, this.constructor);
@@ -19,7 +21,7 @@ class PoketoError extends Error {
 
 class InvalidUrlError extends PoketoError {
   constructor(url: string) {
-    super('INVALID_URL', `Unable to parse url '${url}'`);
+    super('INVALID_URL', `Unable to parse '${url}'`);
   }
 }
 
@@ -31,6 +33,12 @@ class HTTPError extends PoketoError {
     super('HTTP_ERROR', message);
     this.statusCode = statusCode;
     this.url = url;
+  }
+}
+
+class RequestError extends PoketoError {
+  constructor(url: string) {
+    super('REQUEST_ERROR', `Failed to make a request to '${url}'`);
   }
 }
 
@@ -47,15 +55,15 @@ class TimeoutError extends PoketoError {
 }
 
 class UnsupportedSiteError extends PoketoError {
-  constructor(site: string) {
-    super('UNSUPPORTED_SITE', `Site at '${site}' is not supported`);
+  constructor(url: string) {
+    super('UNSUPPORTED_SITE', `Site at '${url}' is not supported`);
   }
 }
 
-class UnsupportedSiteRequestError extends PoketoError {
+class UnsupportedOperationError extends PoketoError {
   constructor(siteName: string, operationName: string) {
     super(
-      'UNSUPPORTED_SITE_REQUEST',
+      'UNSUPPORTED_OPERATION',
       `${siteName} does not support ${operationName}`,
     );
   }
@@ -66,7 +74,8 @@ export default {
   HTTPError,
   InvalidUrlError,
   NotFoundError,
+  RequestError,
   TimeoutError,
   UnsupportedSiteError,
-  UnsupportedSiteRequestError,
+  UnsupportedOperationError,
 };

--- a/src/get.js
+++ b/src/get.js
@@ -1,0 +1,29 @@
+// @flow
+
+import got from 'got';
+import errors from './errors';
+
+type RequestOptions = {
+  json?: boolean,
+  timeout?: number,
+};
+
+async function get(url: string, opts: RequestOptions) {
+  try {
+    return await got(url, opts);
+  } catch (err) {
+    switch (err.name) {
+      case 'HTTPError':
+        if (err.statusCode === 404) {
+          throw new errors.NotFoundError(url);
+        }
+        throw new errors.HTTPError(err.statusCode, err.statusMessage, url);
+      case 'TimeoutError':
+        throw new errors.TimeoutError(err.message, url);
+      default:
+        throw err;
+    }
+  }
+}
+
+export default get;

--- a/src/get.js
+++ b/src/get.js
@@ -12,17 +12,18 @@ async function get(url: string, opts: RequestOptions) {
   try {
     return await got(url, opts);
   } catch (err) {
-    switch (err.name) {
-      case 'HTTPError':
-        if (err.statusCode === 404) {
-          throw new errors.NotFoundError(url);
-        }
-        throw new errors.HTTPError(err.statusCode, err.statusMessage, url);
-      case 'TimeoutError':
-        throw new errors.TimeoutError(err.message, url);
-      default:
-        throw err;
+    if (err instanceof got.HTTPError) {
+      if (err.statusCode === 404) {
+        throw new errors.NotFoundError(url);
+      }
+      throw new errors.HTTPError(err.statusCode, err.statusMessage, url);
+    } else if (err instanceof got.TimeoutError) {
+      throw new errors.TimeoutError(err.message, url);
+    } else if (err instanceof got.RequestError) {
+      throw new errors.RequestError(url);
     }
+
+    throw err;
   }
 }
 

--- a/src/get.js
+++ b/src/get.js
@@ -23,7 +23,7 @@ async function get(url: string, opts: RequestOptions) {
       throw new errors.RequestError(url);
     }
 
-    throw err;
+    throw new errors.PoketoError('ERROR', err.message);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ const poketo: any = {
     const site = getAdapterByUrl(url);
     const parts = site.parseUrl(url);
 
-    invariant(parts.seriesSlug, new Error('Could not read series slug'));
+    invariant(parts.seriesSlug, new errors.InvalidUrlError(url));
 
     const seriesData = await site.getSeries(parts.seriesSlug);
 
@@ -87,7 +87,7 @@ const poketo: any = {
     // NOTE: we don't check for series slug here since some sites (eg. Mangadex)
     // have chapter-only urls (eg. https://mangadex.org/chapter/123456). Only the
     // chapter url is really required.
-    invariant(parts.chapterSlug, new Error('Could not read chapter slug'));
+    invariant(parts.chapterSlug, new errors.InvalidUrlError(url));
 
     const chapterData = await site.getChapter(
       parts.seriesSlug,
@@ -95,7 +95,7 @@ const poketo: any = {
     );
     const seriesSlug = parts.seriesSlug || chapterData.seriesSlug;
 
-    invariant(seriesSlug, new Error('Could not read series slug'));
+    invariant(seriesSlug, new errors.InvalidUrlError(url));
 
     return {
       id: utils.generateId(site.id, seriesSlug, parts.chapterSlug),

--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,15 @@ const poketo: any = {
    * Meant for reconstructing URLs from pieces in routes.
    */
   constructUrl(
-    siteId: string,
-    seriesSlug: string,
+    siteId: ?string,
+    seriesSlug: ?string,
     chapterSlug: ?string,
   ): string {
+    invariant(
+      typeof siteId === 'string',
+      new TypeError(`'siteId' must be a string, not ${typeof siteId}`),
+    );
+
     const site = getAdapterBySiteId(siteId);
     return site.constructUrl(seriesSlug, chapterSlug);
   },

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,6 +10,22 @@ describe('poketo', () => {
         'http://merakiscans.com/senryu-girl/5',
       );
     });
+
+    it('throws a TypeError without arguments', () => {
+      expect(() => {
+        poketo.constructUrl();
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('getSeries', () => {
+    fit('throws for invalid urls', async () => {
+      expect.assertions(1);
+
+      await expect(
+        poketo.getSeries('http://helveticascans.com/r/series/non-existent/'),
+      ).rejects.toThrow(poketo.NotFoundError);
+    });
   });
 
   describe('getChapter', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,11 @@
 // @flow
 
-import got from 'got';
-import cheerio from 'cheerio';
 import normalize from 'normalize-url';
 import pathMatch from 'path-match';
 import probe from 'probe-image-size';
 import { URL, type URLSearchParams } from 'url';
 
+import get from './get';
 import type { ChapterMetadata, PageDimensions } from './types';
 
 const timeout = 5 * 1000;
@@ -121,13 +120,13 @@ export default {
     [site, series, chapter].filter(Boolean).join(':'),
 
   async getPage(url: string): Promise<string> {
-    const res = await got(url, { timeout });
+    const res = await get(url, { timeout });
     const html = res.body;
     return html;
   },
 
   async getJSON(url: string): Promise<Object> {
-    const res = await got(url, { json: true, timeout });
+    const res = await get(url, { json: true, timeout });
     const json = res.body;
     return json;
   },


### PR DESCRIPTION
This PR refines how errors are returned from Poketo, with a few changes:

- [x] All errors returned are either `TypeError` or an instance of `PoketoError`
- [x] All [Got](https://github.com/sindresorhus/got) errors are wrapped in `HTTPError`, `TimeoutError`, or a generic `PoketoError`
- [x] Rename `UnsupportedSiteRequest` to `UnsupportedOperation` to be more explicit

Maybe this is just code for code's sake, but I think having more standardized errors might make interfacing with Poketo a little easier.