### PR TITLE
Accept ID or URL for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![Coverage](https://badgen.net/coveralls/c/github/poketo/node)](https://coveralls.io/github/poketo/node)
 [![npm](https://badgen.now.sh/npm/v/poketo)](https://www.npmjs.com/package/poketo)
 
-Node library for scraping manga aggregator and scanlator sites.
+Node library for scraping manga sites.
 
 People should be able to read content on the web in the way that works for them. Manga sites are often a special brand of bad. Each page is a new page load, ads everywhere, yuck!
 
-This library wraps scraping logic for 15+ sites, providing open access to their content, and an easy way to build readers, downloaders, and more.
+This library wraps scraping logic for 16+ sites, providing open access to their content, and an easy way to build readers, downloaders, and more.
 
 For a working example, check out the [Poketo manga reader](https://poketo.app)!
 
-> :construction: This project is `v0.x.x` and the API is subject to change as more sites are added.
+> :construction: This project is still `v0.x.x` and the API may change as more sites are added.
 
 ## Install
 
@@ -20,7 +20,7 @@ For a working example, check out the [Poketo manga reader](https://poketo.app)!
 npm install poketo --save
 ```
 
-You can also use [api.poketo.app](https://api.poketo.app), a hosted micro-service for this library. See the [poketo service repo](https://github.com/poketo/service) for more.
+You can also use [api.poketo.app](https://api.poketo.app), a hosted micro-service for this library.
 
 ## Usage
 
@@ -29,14 +29,16 @@ import poketo from 'poketo';
 
 poketo.getSeries('http://merakiscans.com/senryu-girl/').then(series => {
   console.log(series);
-  // { id: 'meraki-scans:senryu-girl', title: 'Senryu Girl', chapters: [...], ... }
+  //=> { id: 'meraki-scans:senryu-girl', title: 'Senryu Girl', chapters: [...], ... }
 });
 
 poketo.getChapter('http://merakiscans.com/senryu-girl/5/').then(chapter => {
   console.log(chapter);
-  // { id: 'meraki-scans:senryu-girl:5', pages: [...], ... }
+  //=> { id: 'meraki-scans:senryu-girl:5', pages: [...], ... }
 });
 ```
+
+Full documentation of the [API can be found below](#api).
 
 ## Supported Sites
 
@@ -64,9 +66,29 @@ If there's a site or group you'd like to see supported, [make an issue!](https:/
 
 ## API
 
-#### `poketo.getSeries(url: string): Promise<Series>`
+Poketo exposes four methods:
 
-Get metadata about a series, including for individual chapters (but not pages within those chapters).
+```jsx
+poketo.getSeries(idOrUrl: string): Promise<Series>
+poketo.getChapter(idOrUrl: string): Promise<Chapter>
+poketo.getType(input: string): 'series' | 'chapter'
+poketo.constructUrl(id: string): string
+```
+
+To understand what is returned for a `Series` or `Chapter`, check out the examples below.
+
+## Docs
+
+* [Get series information](#get-series-information)
+* [Get pages for a chapter](#get-pages-for-a-chapter)
+* [Validate a URL or ID](#validate-a-url-or-id)
+* [Convert an ID to a URL](#get-a-url-from-a-poketo-id)
+* [Difference between an ID vs. URL](#whats-the-difference-between-an-id-and-a-url)
+* [Error Handling](#error-handling)
+
+### Get series information
+
+Use `poketo.getSeries` to get the ID, title, cover image, and chapter listing for a manga series.
 
 ```js
 poketo.getSeries('http://merakiscans.com/senryu-girl').then(series => {
@@ -78,11 +100,14 @@ poketo.getSeries('http://merakiscans.com/senryu-girl').then(series => {
 //   slug: 'senryu-girl',
 //   url: 'http://merakiscans.com/senryu-girl',
 //   title: 'Senryu Girl',
+//   coverImageUrl: 'http://merakiscans.com/.../senryu_200x0.jpg',
 //   chapters: [
 //     {
 //       id: 'meraki-scans:senryu-girl:1',
 //       slug: '1',
-//       number: 1,
+//       chapterNumber: '1',
+//       volumeNumber: '1',
+//       title: '5-7-5 Girl',
 //       createdAt: 1522811950
 //     },
 //     ...
@@ -91,9 +116,11 @@ poketo.getSeries('http://merakiscans.com/senryu-girl').then(series => {
 // }
 ```
 
-#### `poketo.getChapter(url: string): Promise<Chapter>`
+### Get pages for a chapter
 
-Get page data for a given chapter. Unlike `poketo.getSeries`, this method does not include much metadata.
+Use `poketo.getChapter` to get a page listing for a chapter. This doesn't include any information about the chapter or series, just the page list.
+
+Depending on the site, the page list will also include image dimensions.
 
 ```js
 poketo.getChapter('http://merakiscans.com/senryu-girl/5').then(chapter => {
@@ -101,7 +128,7 @@ poketo.getChapter('http://merakiscans.com/senryu-girl/5').then(chapter => {
 });
 
 // {
-//  id: 'meraki-scans:senryu-girl:1',
+//  id: 'meraki-scans:senryu-girl:5',
 //  slug: '1',
 //  url: 'http://merakiscans.com/senryu-girl/5',
 //  pages: [
@@ -112,14 +139,79 @@ poketo.getChapter('http://merakiscans.com/senryu-girl/5').then(chapter => {
 // }
 ```
 
-#### `poketo.constructUrl(siteId: string, seriesSlug: ?string, chapterSlug: ?string): string`
+### Validate a URL or ID
 
-Returns a site URL from the pieces passed in. Used to convert between IDs (eg. `meraki-scans:senryu-girl:5`) and URLs (`http://merakiscans.com/senryu-girl/5`). Find a full list of site IDs from the [adapter folder](https://github.com/poketo/node/tree/master/src/adapters).
+If you have an arbitrary input, you can see if Poketo recognizes it by calling the `poketo.getType` method. It will return `'series'` or `'chapter'` if it's supported, or will throw [a Poketo error](#error-handling) if not.
 
 ```js
-const url = poketo.constructUrl('meraki-scans', 'senryu-girl', '5');
-// http://merakiscans.com/senryu-girl/5
+poketo.getType('http://merakiscans.com/senryu-girl');
+//=> 'series'
+poketo.getType('http://merakiscans.com/senryu-girl/5');
+//=> 'chapter'
+poketo.getType('http://merakiscans.com/i/am/a/banana/yo');
+//=> throws a `poketo.InvalidUrlError`
+poketo.getType('http://google.com');
+//=> throws a `poketo.UnsupportedSiteError`
 ```
+
+### Get a URL from a Poketo ID
+
+If you've stored a Poketo ID, you can get a URL back out by using the `poketo.constructUrl` method. You can learn more about [the difference between IDs and URLs](#whats-the-difference-between-an-id-and-a-url).
+
+```js
+poketo.constructUrl('meraki-scans:senryu-girl:5');
+//=> http://merakiscans.com/senryu-girl/5
+
+poketo.constructUrl('manga-stream:haikyuu:314/5286');
+//=> https://readms.net/r/haikyuu/314/5286/1
+```
+
+### What's the difference between an ID and a URL?
+
+Poketo scrapes information from many sites. To identify which _site_, _series_ (aka. manga), and _chapter_ you're talking about, Poketo lets you provide information in two ways: a Poketo ID or a URL.
+
+These IDs below are equivalent to the URLs on their right:
+
+```
+ID                                URL
+mangadex:13127:311433          →  https://mangadex.org/chapter/311433/1
+meraki-scans:senryu-girl:5     →  http://merakiscans.com/senryu-girl/5
+manga-stream:haikyuu:314/5286  →  https://readms.net/r/haikyuu/314/5286/1
+```
+
+For the `getSeries` and `getChapter` methods, you can provide either a URL, or an ID, like so:
+
+```jsx
+// Both lines return the same series
+poketo.getSeries('http://merakiscans.com/senryu-girl/');
+poketo.getSeries('meraki-scans:senryu-girl');
+
+// Both lines return the same chapter
+poketo.getChapter('https://mangadex.org/chapter/311433/1');
+poketo.getChapter('mangadex:13127:311433');
+```
+
+#### Why use an ID?
+
+Poketo IDs have stronger guarantees they won't change.
+
+It's not uncommon for a site to change their domain name or URL structure. If that happens, the URL might break, but Poketo will know to do the right thing with an ID. This makes IDs a better way to store information about a series.
+
+Of course, there are no true guarantees with scraping. Even an ID that works one day might break the next — but it's a _slightly_ better guarantee.
+
+### Error Handling
+
+Scraping isn't a perfect. When using Poketo you'll inevitably run into an error, so we try to make what happened as clear as possible.
+
+* `RequestError` - unable to make a request to scrape the site
+* `TimeoutError` - tried to make a request, but the source site didn't respond in a reasonable time. Defaults to 5 seconds.
+* `HTTPError` - tried to scrape the source site, but the site returned an error (eg. 404, 500)
+* `UnsupportedSiteError` - the site you're trying to scrape from isn't supported. If you'd like to see it supported, [make an issue!](https://github.com/poketo/node/issues/new)
+* `UnsupportedOperationError` - some sites don't support reading chapters. This error is thrown if you call `poketo.getChapter` for these sites.
+
+## Contributing
+
+Contributions are welcome! Poketo is meant to be built on, so feel free to propose ideas or changes that would make it work for your situation — whether it's a bug report, site request, or contributed code.
 
 ## License
 

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -487,3 +487,33 @@ Object {
   "url": "https://helveticascans.com/r/read/talentless-nana/en/1/2/page/1",
 }
 `;
+
+exports[`poketo getSeries returns a series with metadata 1`] = `
+Object {
+  "id": "mangadex:13127",
+  "site": Object {
+    "id": "mangadex",
+    "name": "Mangadex",
+  },
+  "slug": "13127",
+  "supportsReading": true,
+  "title": "Uramikoi, Koi, Uramikoi.",
+  "updatedAt": Any<Number>,
+  "url": "https://mangadex.org/manga/13127",
+}
+`;
+
+exports[`poketo getSeries returns a series with metadata 2`] = `
+Object {
+  "id": "mangadex:13127",
+  "site": Object {
+    "id": "mangadex",
+    "name": "Mangadex",
+  },
+  "slug": "13127",
+  "supportsReading": true,
+  "title": "Uramikoi, Koi, Uramikoi.",
+  "updatedAt": Any<Number>,
+  "url": "https://mangadex.org/manga/13127",
+}
+`;

--- a/src/adapters/sen-manga.js
+++ b/src/adapters/sen-manga.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { URLSearchParams } from 'url';
 import cheerio from 'cheerio';
 import moment from 'moment-timezone';
 import cookie from 'cookie';

--- a/src/errors.js
+++ b/src/errors.js
@@ -3,6 +3,7 @@
 type ErrorCode =
   | 'ERROR'
   | 'HTTP_ERROR'
+  | 'INVALID_ID'
   | 'INVALID_URL'
   | 'REQUEST_ERROR'
   | 'UNSUPPORTED_SITE'
@@ -17,6 +18,12 @@ class PoketoError extends Error {
     Error.captureStackTrace(this, this.constructor);
     this.name = this.constructor.name;
     this.code = errorCode;
+  }
+}
+
+class InvalidIdError extends PoketoError {
+  constructor(id: string) {
+    super('INVALID_ID', `'${id}' is not a valid Poketo ID`);
   }
 }
 
@@ -57,7 +64,7 @@ class TimeoutError extends PoketoError {
 
 class UnsupportedSiteError extends PoketoError {
   constructor(url: string) {
-    super('UNSUPPORTED_SITE', `Site at '${url}' is not supported`);
+    super('UNSUPPORTED_SITE', `Site '${url}' is not supported`);
   }
 }
 
@@ -73,6 +80,7 @@ class UnsupportedOperationError extends PoketoError {
 export default {
   PoketoError,
   HTTPError,
+  InvalidIdError,
   InvalidUrlError,
   NotFoundError,
   RequestError,

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,41 @@ import utils, { invariant } from './utils';
 
 import type { Chapter, ChapterMetadata, SiteAdapter, Series } from './types';
 
+function isUrl(input: string) {
+  return /^https?/.test(input);
+}
+
+function isPoketoId(input: string) {
+  const components = input.split(':');
+  const isValidId = components.length > 1 && components.length < 4;
+  return !isUrl(input) && isValidId;
+}
+
+function isChapter(components: Object) {
+  return (
+    components.chapterSlug !== null && components.chapterSlug !== undefined
+  );
+}
+
+function parseId(
+  id: string,
+): {
+  siteId: string,
+  seriesSlug: string,
+  chapterSlug: ?string,
+} {
+  invariant(isPoketoId(id), new errors.InvalidIdError(id));
+
+  const components = id.split(':');
+
+  const [siteId, seriesSlug, chapterSlug] = components;
+  const isValidSiteId = adapters.map(adapter => adapter.id).includes(siteId);
+
+  invariant(isValidSiteId, new errors.UnsupportedSiteError(siteId));
+
+  return { siteId, seriesSlug, chapterSlug };
+}
+
 function getAdapterByUrl(url: string): SiteAdapter {
   const adapter = adapters.find(adapter => adapter.supportsUrl(url));
   invariant(adapter, new errors.UnsupportedSiteError(url));
@@ -25,18 +60,36 @@ const poketo: any = {
    *
    * Meant for reconstructing URLs from pieces in routes.
    */
-  constructUrl(
-    siteId: ?string,
-    seriesSlug: ?string,
-    chapterSlug: ?string,
-  ): string {
+  constructUrl(id: ?mixed): string {
     invariant(
-      typeof siteId === 'string',
-      new TypeError(`'siteId' must be a string, not ${typeof siteId}`),
+      typeof id === 'string',
+      new TypeError(`'id' must be a string, not ${typeof id}`),
     );
 
-    const site = getAdapterBySiteId(siteId);
-    return site.constructUrl(seriesSlug, chapterSlug);
+    const components = parseId(id);
+
+    const site = getAdapterBySiteId(components.siteId);
+    return site.constructUrl(components.seriesSlug, components.chapterSlug);
+  },
+
+  isType(input: ?mixed): 'series' | 'chapter' {
+    invariant(
+      typeof input === 'string',
+      new TypeError(`'input' must be a string, not ${typeof input}`),
+    );
+
+    let components;
+
+    if (isPoketoId(input)) {
+      components = parseId(input);
+    } else if (isUrl(input)) {
+      const site = getAdapterByUrl(input);
+      components = site.parseUrl(input);
+    } else {
+      throw new TypeError(`'input' must be a URL or a Poketo ID`);
+    }
+
+    return isChapter(components) ? 'chapter' : 'series';
   },
 
   /**

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -66,13 +66,22 @@ describe('poketo', () => {
     });
 
     it('throws errors on invalid arguments', () => {
-      expect(() => poketo.getType('hello')).toThrow(poketo.InvalidIdError);
-      expect(() => poketo.getType('google:my-series')).toThrow(
-        poketo.UnsupportedSiteError,
-      );
-      expect(() =>
-        poketo.getType('https://google.com/chapter/420649/1'),
-      ).toThrow(poketo.UnsupportedSiteError);
+      const invalidIds = ['hello', 'h8942nrm23cl;.,/,./23,./'];
+      const unsupportedIds = [
+        'https://google.com/chapter/420649/1',
+        'google:my-series',
+        'example:series:chapter-5',
+      ];
+
+      const getType = input => () => poketo.getType(input);
+
+      invalidIds.forEach(input => {
+        expect(getType(input)).toThrow(poketo.InvalidIdError);
+      });
+
+      unsupportedIds.forEach(input => {
+        expect(getType(input)).toThrow(poketo.UnsupportedSiteError);
+      });
     });
   });
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,18 +3,81 @@ import poketo from '.';
 describe('poketo', () => {
   describe('constructUrl', () => {
     it('returns a site-specific url', () => {
-      expect(
-        poketo.constructUrl('mangakakalot', 'urami_koi_koi_urami_koi'),
-      ).toEqual('http://mangakakalot.com/manga/urami_koi_koi_urami_koi');
-      expect(poketo.constructUrl('meraki-scans', 'senryu-girl', '5')).toEqual(
-        'http://merakiscans.com/senryu-girl/5',
-      );
+      const tests = [
+        {
+          input: 'mangakakalot:urami_koi_koi_urami_koi',
+          output: 'http://mangakakalot.com/manga/urami_koi_koi_urami_koi',
+        },
+        {
+          input: 'meraki-scans:senryu-girl:5',
+          output: 'http://merakiscans.com/senryu-girl/5',
+        },
+      ];
+
+      tests.forEach(test => {
+        expect(poketo.constructUrl(test.input)).toEqual(test.output);
+      });
     });
 
     it('throws a TypeError without arguments', () => {
       expect(() => {
         poketo.constructUrl();
       }).toThrow(TypeError);
+    });
+
+    it('throws an InvalidIdError on invalid arguments', () => {
+      expect(() => {
+        poketo.constructUrl('https://google.com');
+      }).toThrow(poketo.InvalidIdError);
+    });
+
+    it('throws an UnsupportedSiteError on invalid arguments', () => {
+      expect(() => {
+        poketo.constructUrl('google:my-series');
+      }).toThrow(poketo.UnsupportedSiteError);
+    });
+  });
+
+  describe('isType', () => {
+    it(`returns 'series' for series inputs`, () => {
+      const inputs = [
+        'https://merakiscans.com/senryu-girl',
+        'meraki-scans:senryu-girl',
+        'sen-manga:Yotsubato!',
+        'https://mangadex.org/manga/420649',
+        'https://mangarock.com/manga/mrs-serie-100100972',
+        'https://jaiminisbox.com/reader/series/my-hero-academia',
+      ];
+
+      inputs.forEach(input => expect(poketo.isType(input)).toEqual('series'));
+    });
+
+    it(`returns 'chapter' for chapter inputs`, () => {
+      const inputs = [
+        'https://merakiscans.com/senryu-girl/5',
+        'meraki-scans:senryu-girl:5',
+        'sen-manga:Yotsubato!:82',
+        'https://mangadex.org/chapter/420649/1',
+        'https://mangarock.com/manga/mrs-serie-100100972/chapter/mrs-chapter-100268832',
+        'https://jaiminisbox.com/reader/read/my-hero-academia/en/0/191/page/1',
+      ];
+
+      inputs.forEach(input => expect(poketo.isType(input)).toEqual('chapter'));
+    });
+
+    it('throws an TypeError on invalid arguments', () => {
+      expect(() => {
+        poketo.isType('hello');
+      }).toThrow(TypeError);
+    });
+
+    it('throws an UnsupportedSiteError on invalid arguments', () => {
+      expect(() => {
+        poketo.isType('google:my-series');
+      }).toThrow(poketo.UnsupportedSiteError);
+      expect(() => {
+        poketo.isType('https://google.com/chapter/420649/1');
+      }).toThrow(poketo.UnsupportedSiteError);
     });
   });
 

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,12 @@ export type Page = {
   height?: number,
 };
 
+export type IdComponents = {
+  siteId: string,
+  seriesSlug: ?string,
+  chapterSlug: ?string,
+};
+
 type BaseChapter = {
   slug: string,
 };
@@ -46,9 +52,7 @@ export type SiteAdapter = {
   constructUrl: (seriesSlug: ?string, chapterSlug: ?string) => string,
   supportsUrl: (url: string) => boolean,
   supportsReading: () => boolean,
-  parseUrl: (
-    url: string,
-  ) => { seriesSlug: string | null, chapterSlug: string | null },
+  parseUrl: (url: string) => { seriesSlug: ?string, chapterSlug: ?string },
   getSeries: (
     seriesSlug: string,
   ) => Promise<{


### PR DESCRIPTION
This PR adds a few new API features to make Poketo easier to work with. These changes are meant to simplify chunks of code [like this one](https://github.com/poketo/service/blob/e903b3f54815bcfaef995645d525fa948c8d7615/lib/server.js#L204-L224) by letting Poketo determine if an ID is in the right format, rather than users.

### Changes

- [x] Change `constructUrl` to take an ID, not a set of components
- [x] Allow using IDs or URLs for `getSeries` and `getChapter`
- [x] Add feature to detect supported inputs (the new `getType` method)
- [x] Throw errors on invalid arguments (TypeError for non-string args, InvalidIdError for bad inputs)
- [x] Fix pre-Node 10.0.0 compatibility by [explicitly importing](https://github.com/poketo/node/blob/a764fbba72615a5c196d46c91d9ac70c44a97470/src/adapters/sen-manga.js#L3) `URLSearchParams`