### PR TITLE
Fix MangaDex urls

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -500,7 +500,7 @@ Object {
   "supportsReading": true,
   "title": "Uramikoi, Koi, Uramikoi.",
   "updatedAt": Any<Number>,
-  "url": "https://mangadex.org/manga/13127",
+  "url": "https://mangadex.org/title/13127",
 }
 `;
 
@@ -516,6 +516,6 @@ Object {
   "supportsReading": true,
   "title": "Uramikoi, Koi, Uramikoi.",
   "updatedAt": Any<Number>,
-  "url": "https://mangadex.org/manga/13127",
+  "url": "https://mangadex.org/title/13127",
 }
 `;

--- a/src/adapters/__snapshots__/mangadex.test.js.snap
+++ b/src/adapters/__snapshots__/mangadex.test.js.snap
@@ -12,7 +12,7 @@ Object {
   "supportsReading": true,
   "title": "Uramikoi, Koi, Uramikoi.",
   "updatedAt": Any<Number>,
-  "url": "http://localhost:57163/manga/13127",
+  "url": "http://localhost:57163/title/13127",
 }
 `;
 

--- a/src/adapters/mangadex.js
+++ b/src/adapters/mangadex.js
@@ -27,13 +27,13 @@ const MangadexAdapter: SiteAdapter = {
   },
 
   parseUrl(url) {
-    // https://mangadex.org/manga/13127
+    // https://mangadex.org/title/13127
     // https://mangadex.org/manga/13127/uramikoi-koi-uramikoi
     // https://mangadex.org/chapter/37149/1
 
     const matches = utils.pathMatch(
       url,
-      '/:type(manga|chapter)/:first/:second?',
+      '/:type(manga|title|chapter)/:first/:second?',
     );
 
     invariant(matches, new errors.InvalidUrlError(url));
@@ -47,7 +47,7 @@ const MangadexAdapter: SiteAdapter = {
   },
 
   constructUrl(seriesSlug, chapterSlug) {
-    const type = chapterSlug ? 'chapter' : 'manga';
+    const type = chapterSlug ? 'chapter' : 'title';
     const slug = type === 'chapter' ? chapterSlug : seriesSlug;
 
     invariant(

--- a/src/adapters/mangadex.test.js
+++ b/src/adapters/mangadex.test.js
@@ -16,7 +16,7 @@ describe('MangadexAdapter', () => {
 
   describe('parseUrl', () => {
     it('returns the components of a url', () => {
-      expect(adapter.parseUrl('https://mangadex.org/manga/13127')).toEqual({
+      expect(adapter.parseUrl('https://mangadex.org/title/13127')).toEqual({
         seriesSlug: '13127',
         chapterSlug: null,
       });
@@ -24,6 +24,13 @@ describe('MangadexAdapter', () => {
       expect(adapter.parseUrl('https://mangadex.org/chapter/47721')).toEqual({
         seriesSlug: null,
         chapterSlug: '47721',
+      });
+    });
+
+    it('supports legacy MangaDex urls', () => {
+      expect(adapter.parseUrl('https://mangadex.org/manga/13127')).toEqual({
+        seriesSlug: '13127',
+        chapterSlug: null,
       });
     });
 


### PR DESCRIPTION
MangaDex recently switched their URL structure to use the term `title` instead of `manga`

So this URL:

```
https://mangadex.org/manga/13127
```

Became this URL:

```
https://mangadex.org/title/13127
```

This PR adds support for this change. Old `manga` URLs are still supported, both on MangaDex and Poketo, but `title` is the new default.